### PR TITLE
Add MAC address to wemo discovery attributes

### DIFF
--- a/netdisco/discoverables/belkin_wemo.py
+++ b/netdisco/discoverables/belkin_wemo.py
@@ -11,7 +11,7 @@ class Discoverable(SSDPDiscoverable):
         device = entry.description['device']
 
         return (device['friendlyName'], device['modelName'],
-                entry.values['location'])
+                entry.values['location'], device['macAddress'])
 
     def get_entries(self):
         """ Returns all Belkin Wemo entries. """


### PR DESCRIPTION
Needed for pywemo 0.3.2, and for this fix https://github.com/balloob/home-assistant/issues/476