### PR TITLE
Handle mac address missing in early wemo firmware.

### DIFF
--- a/netdisco/discoverables/belkin_wemo.py
+++ b/netdisco/discoverables/belkin_wemo.py
@@ -11,7 +11,7 @@ class Discoverable(SSDPDiscoverable):
         device = entry.description['device']
 
         return (device['friendlyName'], device['modelName'],
-                entry.values['location'], device['macAddress'])
+                entry.values['location'], device.get('macAddress', ''))
 
     def get_entries(self):
         """ Returns all Belkin Wemo entries. """


### PR DESCRIPTION
Some early Wemo firmware doesn't return the mac address - this PR handles this without throwing an exception. 