### PR TITLE
Add serial number to wemo discovery info

### DIFF
--- a/netdisco/discoverables/belkin_wemo.py
+++ b/netdisco/discoverables/belkin_wemo.py
@@ -11,7 +11,8 @@ class Discoverable(SSDPDiscoverable):
         device = entry.description['device']
 
         return (device['friendlyName'], device['modelName'],
-                entry.values['location'], device.get('macAddress', ''))
+                entry.values['location'], device.get('macAddress', ''),
+                device['serialNumber'])
 
     def get_entries(self):
         """ Returns all Belkin Wemo entries. """

--- a/setup.py
+++ b/setup.py
@@ -1,7 +1,7 @@
 from setuptools import setup, find_packages
 
 setup(name='netdisco',
-      version='0.5.3',
+      version='0.5.4',
       description='Discover devices on your local network',
       url='http://github.com/balloob/netdisco',
       author='Paulus Schoutsen',


### PR DESCRIPTION
balloob/home-assistant#1453 adds a serial number to uniquely identify WeMo devices. This updates netdisco to provide the same information when it discovers a WeMo device.