### PR TITLE
Fix uPNP ping of death packet.

### DIFF
--- a/netdisco/ssdp.py
+++ b/netdisco/ssdp.py
@@ -14,7 +14,7 @@ import requests
 from .util import etree_to_dict
 
 DISCOVER_TIMEOUT = 5
-SSDP_MX = 0
+SSDP_MX = 1
 
 RESPONSE_REGEX = re.compile(r'\n(.*)\: (.*)\r')
 


### PR DESCRIPTION
Sending an M-SEARCH request with MX: 0 crashes random uPNP listeners.

- Cisco EPC3925 (balloob/home-assistant#1557)
- Netgear router (@BryonCLewis on home-assistant gitter)
- Old Roku clients (http://forums.roku.com/viewtopic.php?p=523858&sid=daad2638e2622bcce868e89497930fad)