### PR TITLE
Add support for discovery of Tellstick Net devices

### DIFF
--- a/netdisco/discoverables/tellstick.py
+++ b/netdisco/discoverables/tellstick.py
@@ -1,0 +1,13 @@
+""" Discovers Tellstick devices. """
+
+from . import BaseDiscoverable
+
+
+class Discoverable(BaseDiscoverable):
+    """ Adds support for discovering a Tellstick device. """
+
+    def __init__(self, netdis):
+        self._netdis = netdis
+
+    def get_entries(self):
+        return self._netdis.tellstick.entries

--- a/netdisco/discovery.py
+++ b/netdisco/discovery.py
@@ -10,6 +10,7 @@ from .ssdp import SSDP
 from .mdns import MDNS
 from .gdm import GDM
 from .lms import LMS
+from .tellstick import Tellstick
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -22,6 +23,7 @@ class NetworkDiscovery(object):
     SSDP scans in the foreground.
     GDM scans in the foreground.
     LMS scans in the foreground.
+    Tellstick scans in the foreground
 
     start: is ready to scan
     scan: scan the network
@@ -37,6 +39,7 @@ class NetworkDiscovery(object):
         self.ssdp = SSDP()
         self.gdm = GDM()
         self.lms = LMS()
+        self.tellstick = Tellstick()
         self.discoverables = {}
 
         self._load_device_support()
@@ -52,6 +55,7 @@ class NetworkDiscovery(object):
         self.ssdp.scan()
         self.gdm.scan()
         self.lms.scan()
+        self.tellstick.scan()
 
     def stop(self):
         """ Turn discovery off. """
@@ -124,3 +128,6 @@ class NetworkDiscovery(object):
         print("")
         print("LMS")
         pprint(self.lms.entries)
+        print("")
+        print("Tellstick")
+        pprint(self.tellstick.entries)

--- a/netdisco/tellstick.py
+++ b/netdisco/tellstick.py
@@ -1,0 +1,58 @@
+"""
+Tellstick device discovery.
+"""
+import socket
+import threading
+from datetime import timedelta
+
+
+DISCOVERY_PORT = 30303
+DISCOVERY_ADDRESS = '<broadcast>'
+DISCOVERY_PAYLOAD = b"D"
+DISCOVERY_TIMEOUT = timedelta(seconds=5)
+
+
+class Tellstick(object):
+    """Base class to discover Tellstick devices."""
+
+    def __init__(self):
+        self.entries = []
+        self._lock = threading.RLock()
+
+    def scan(self):
+        """Scan the network."""
+        with self._lock:
+            self.update()
+
+    def all(self):
+        """Scan and return all found entries."""
+        self.scan()
+        return self.entries
+
+    def update(self):
+        """Scan network for Tellstick devices."""
+        entries = []
+        with socket.socket(socket.AF_INET, socket.SOCK_DGRAM) as sock:
+            sock.setsockopt(socket.SOL_SOCKET, socket.SO_BROADCAST, 1)
+            sock.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
+            sock.settimeout(DISCOVERY_TIMEOUT.seconds)
+            sock.sendto(DISCOVERY_PAYLOAD, (DISCOVERY_ADDRESS, DISCOVERY_PORT))
+            while True:
+                try:
+                    data, (address, port) = sock.recvfrom(1024)
+                    entry = data.decode("ascii").split(":")
+                    if len(entry) != 4: # expecting product, mac, activation code, version
+                        continue
+                    entry = (address,) + tuple(entry)
+                    entries.append(entry)
+                except socket.timeout:
+                    break
+
+            self.entries = entries
+
+if __name__ == "__main__":
+    from pprint import pprint
+    tellstick = Tellstick()
+    pprint("Scanning for Tellstick devices..")
+    tellstick.update()
+    pprint(tellstick.entries)


### PR DESCRIPTION
Add discovery of Tellstick Net devices (http://www.telldus.se/products/tellstick_net).
Tellstick Net devices can receive commands and also be asked for sensor updates on the local network. For Tellstick Net devices on the same network as the client, this will make it possible for faster and connectivity-independent updates than by using the Telldus Live online service.