### PR TITLE
Bind sockets to interface addresses when sending ssdp requests

### DIFF
--- a/netdisco/util.py
+++ b/netdisco/util.py
@@ -3,6 +3,8 @@ Util functions used by Netdisco
 """
 from collections import defaultdict
 
+import netifaces
+
 
 # Taken from http://stackoverflow.com/a/10077069
 def etree_to_dict(t):
@@ -29,3 +31,12 @@ def etree_to_dict(t):
         else:
             d[tag_name] = text
     return d
+
+
+def interface_addresses(family=netifaces.AF_INET):
+    """Returns local addresses of any network associated with a local interface
+    that has broadcast (and probably multicast) capability."""
+    return [addr['addr']
+            for i in netifaces.interfaces()
+            for addr in netifaces.ifaddresses(i).get(family) or []
+            if 'broadcast' in addr]

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,3 @@
 zeroconf>=0.17.4
 requests>=2.0
+netifaces>=0.10.0

--- a/setup.py
+++ b/setup.py
@@ -7,6 +7,6 @@ setup(name='netdisco',
       author='Paulus Schoutsen',
       author_email='Paulus@PaulusSchoutsen.nl',
       license='MIT',
-      install_requires=['requests>=2.0', 'zeroconf>=0.17.4'],
+      install_requires=['netifaces>=0.10.0', 'requests>=2.0', 'zeroconf>=0.17.4'],
       packages=find_packages(),
       zip_safe=False)


### PR DESCRIPTION
This fix was needed for SSDP discovery on Windows 10 (pavoni/pywemo#23).
Proposing it as a PR here because the code is basically identical.

Not sure if similar fixes are needed for gdm (also multicast) and lms (broadcast), but I don't have Windows systems to test on.