### PR TITLE
sock.recv(1024).decode("utf-8") instead of "ascii"

### DIFF
--- a/netdisco/ssdp.py
+++ b/netdisco/ssdp.py
@@ -203,7 +203,7 @@ def scan(st=None, timeout=DISCOVER_TIMEOUT, max_entries=None):
         'MAN: "ssdp:discover"',
         'MX: {:d}'.format(SSDP_MX),
         'ST: {}'.format(ssdp_st),
-        '', '']).encode('ascii')
+        '', '']).encode('utf-8')
 
     stop_wait = datetime.now() + timedelta(0, timeout)
 
@@ -232,7 +232,7 @@ def scan(st=None, timeout=DISCOVER_TIMEOUT, max_entries=None):
             ready = select.select(sockets, [], [], seconds_left)[0]
 
             for sock in ready:
-                response = sock.recv(1024).decode("ascii")
+                response = sock.recv(1024).decode("utf-8")
 
                 entry = UPNPEntry.from_response(response)
 


### PR DESCRIPTION
Returned data on socket might contain non-ascii values in scan.
  File "/.../netdisco-0.6.1-py3.5.egg/netdisco/ssdp.py", line 235, in scan
    response = sock.recv(1024).decode("ascii")
UnicodeDecodeError: 'ascii' codec can't decode byte 0xc3 in position 53: ordinal not in range(128)

I had nothing but ascii in the output from python -m netdisco, but there was obviously something in the packets...

MiniDLNA sent DATE localized...